### PR TITLE
Limit read to BUF_SZ to prevent out-of-bounds write in decode_msg

### DIFF
--- a/src/net.c
+++ b/src/net.c
@@ -248,8 +248,9 @@ void service_socket(pmtr_t *cfg) {
   ssize_t rc;
   int *fd = (int*)utarray_front(cfg->listen); assert(fd);
   do {
-    rc = read(*fd, buf, sizeof(buf));   /* fd is non-blocking, thus */
-    if (rc > 0) decode_msg(cfg,buf,rc); /* we get rc==-1 after last */
+    /* limit read to BUF_SZ to prevent out-of-bounds in decode_msg */
+    rc = read(*fd, buf, BUF_SZ);
+    if (rc > 0) decode_msg(cfg, buf, rc);
   } while (rc >= 0);
 }
 


### PR DESCRIPTION
**Bug:** `service_socket` reads up to `BUF_SZ+1` bytes into `buf[BUF_SZ+1]`, and `decode_msg` may write a null byte at `buf[n]` (where `n` can be `BUF_SZ+1`), causing an out-of-bounds write.

**Impact:** A remote attacker can send a carefully crafted UDP datagram of length `BUF_SZ+1` (2001 bytes) to the pmtr listener and trigger an out-of-bounds write on the stack, potentially leading to crashes or code execution.

**Exploitation:** Sending a 2001-byte UDP packet to the configured listen port.