### PR TITLE
Fix potential report_id buffer overflow in set_report

### DIFF
--- a/src/net.c
+++ b/src/net.c
@@ -132,6 +132,8 @@ void set_report(parse_t *ps, char *dest) {
   if (fcntl(fd, F_SETFD, flags) == -1) {rc = -3; goto done;}
 
   gethostname(ps->cfg->report_id, sizeof(ps->cfg->report_id));
+  /* ensure null-termination in case hostname length >= buffer */
+  ps->cfg->report_id[sizeof(ps->cfg->report_id) - 1] = '\0';
 
   /* use a specific NIC if one was specified, supported here for multicast */
   if (iface) {
@@ -151,8 +153,21 @@ void set_report(parse_t *ps, char *dest) {
     if (ioctl(fd, SIOCGIFADDR, &ifr)) {utstring_printf(ps->em,"ioctl: %s\n", strerror(errno)); goto done;} 
     iface_addr = (((struct sockaddr_in *)&ifr.ifr_addr)->sin_addr);
     // utstring_printf(ps->em,"iface %s has addr %s\n", iface, inet_ntoa(iface_addr));
-    strcat(ps->cfg->report_id, " ");
-    strcat(ps->cfg->report_id, inet_ntoa(iface_addr));
+    {
+      /* append space and interface address safely */
+      size_t ridx = strlen(ps->cfg->report_id);
+      const char *ip = inet_ntoa(iface_addr);
+      size_t iplen = strlen(ip);
+      if (ridx + 1 + iplen < sizeof(ps->cfg->report_id)) {
+        ps->cfg->report_id[ridx] = ' ';
+        ps->cfg->report_id[ridx + 1] = '\0';
+        strncat(ps->cfg->report_id, ip,
+                sizeof(ps->cfg->report_id) - ridx - 1);
+      } else {
+        utstring_printf(ps->em, "report_id buffer overflow prevented\n");
+        goto done;
+      }
+    }
 
     /* ask kernel to use its IP address for outgoing multicast */
     if (setsockopt(fd, IPPROTO_IP, IP_MULTICAST_IF, &iface_addr, sizeof(iface_addr))) {


### PR DESCRIPTION
**Bug:** Potential out-of-bounds write in `set_report` when concatenating the hostname and interface IP into `report_id[100]`.

**Impact:** A hostname of length ≥100 bytes (resulting in no null terminator) or appending the interface address to a full buffer can overflow `report_id`, leading to memory corruption, crashes, or potential arbitrary code execution.

**Exploitation:** If the system hostname is manipulated to a 100-byte string with no null terminator, then `gethostname` truncates without adding a terminator. A subsequent `strcat` to append a space and interface address writes past the end of the buffer.